### PR TITLE
Update bazel to 6.3.2 and runtime to 23.08

### DIFF
--- a/org.freedesktop.Sdk.Extension.bazel.appdata.xml
+++ b/org.freedesktop.Sdk.Extension.bazel.appdata.xml
@@ -8,6 +8,7 @@
   <project_license>Apache-2.0</project_license>
   <metadata_license>CC0-1.0</metadata_license>
   <releases>
+    <release version="6.2.1" date="2023-06-02"/>
     <release version="4.0.0" date="2021-01-21"/>
   </releases>
 </component>

--- a/org.freedesktop.Sdk.Extension.bazel.yaml
+++ b/org.freedesktop.Sdk.Extension.bazel.yaml
@@ -1,26 +1,30 @@
 id: org.freedesktop.Sdk.Extension.bazel
-branch: '20.08'
+branch: '23.08'
 runtime: org.freedesktop.Sdk
 build-extension: true
 sdk: org.freedesktop.Sdk
-runtime-version: '20.08'
+runtime-version: '23.08'
 separate-locales: false
 appstream-compose: false
 modules:
   - name: bazel
     buildsystem: simple
+    build-options:
+      strip: false
+      no-debuginfo: true
+      no-debuginfo-compression: true
     sources:
       - type: file
         only-arches:
           - x86_64
-        url: https://github.com/bazelbuild/bazel/releases/download/4.0.0/bazel-4.0.0-linux-x86_64
-        sha256: 7bee349a626281fc8b8d04a7a0b0358492712377400ab12533aeb39c2eb2b901
+        url: https://github.com/bazelbuild/bazel/releases/download/6.3.2/bazel-6.3.2-linux-x86_64
+        sha256: e78fc3394deae5408d6f49a15c7b1e615901969ecf6e50d55ef899996b0b8458
         dest-filename: bazel
       - type: file
         only-arches:
           - aarch64
-        url: https://github.com/bazelbuild/bazel/releases/download/4.0.0/bazel-4.0.0-linux-arm64
-        sha256: a714c94ffccfacd20e5ea15d94ea26b3d64c9e1a12c048355f18b38cbe32d6ae
+        url: https://github.com/bazelbuild/bazel/releases/download/6.3.2/bazel-6.3.2-linux-arm64
+        sha256: 9d88a0b206e22cceb4afe0060be7f294b423f5f49b18750fbbd7abd47cea4054
         dest-filename: bazel
     build-commands:
       - chmod +x bazel


### PR DESCRIPTION
I searched through GitHub and there seems to be no consumer of this extension. If anyone requires bazel4/5 later down the line for compatibility reasons I guess we can create separate branches/repo. Meanwhile, I think this should follow the latest bazel LTS release.

If there is any objection to it I can convert this to just update the runtime since 20.08 is long EOL.

Stripping and debug info generation is disabled per https://github.com/bazelbuild/bazel/issues/600

cc @albert-tomanek