### PR TITLE
Update bazel to the 7.3.2 in the branch/24.08

### DIFF
--- a/org.freedesktop.Sdk.Extension.bazel.metainfo.xml
+++ b/org.freedesktop.Sdk.Extension.bazel.metainfo.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <component type="runtime">
   <id>org.freedesktop.Sdk.Extension.bazel</id>
   <name>Bazel</name>
@@ -8,6 +8,7 @@
   <project_license>Apache-2.0</project_license>
   <metadata_license>CC0-1.0</metadata_license>
   <releases>
+    <release version="7.3.2" date="2024-10-01"/>
     <release version="7.3.1" date="2024-08-19"/>
     <release version="7.1.1" date="2024-03-21"/>
     <release version="6.2.1" date="2023-06-02"/>

--- a/org.freedesktop.Sdk.Extension.bazel.yaml
+++ b/org.freedesktop.Sdk.Extension.bazel.yaml
@@ -16,14 +16,14 @@ modules:
       - type: file
         only-arches:
           - x86_64
-        url: https://github.com/bazelbuild/bazel/releases/download/7.3.1/bazel-7.3.1-linux-x86_64
-        sha256: 794f58b5a5c28c4729f04db0bd1238eaf827105bb49946238b00f681a1da377c
+        url: https://github.com/bazelbuild/bazel/releases/download/7.3.2/bazel-7.3.2-linux-x86_64
+        sha256: 96e9c34caf77b25a2fe1f0699cb85d23226a7a9f563ac156f0ed2033402b080b
         dest-filename: bazel
       - type: file
         only-arches:
           - aarch64
-        url: https://github.com/bazelbuild/bazel/releases/download/7.3.1/bazel-7.3.1-linux-arm64
-        sha256: 95871a3dc9db88043fb54752ce2155d702bbad809b0e5f0c428a67c0522e5944
+        url: https://github.com/bazelbuild/bazel/releases/download/7.3.2/bazel-7.3.2-linux-arm64
+        sha256: dbfd5d4dc8087f16aaa355a0a717756763ca2028af34d13981a31dc1c2bf1285
         dest-filename: bazel
     build-commands:
       - chmod +x bazel


### PR DESCRIPTION
This pull request updates bazel to the latest release version 7.3.2 in the branch/24.08 branch of org.freedesktop.Sdk.Extension.bazel.