### PR TITLE
Add <p> tags to description to pass flatpak-builder-lint check

### DIFF
--- a/org.freedesktop.Sdk.Extension.bazel.metainfo.xml
+++ b/org.freedesktop.Sdk.Extension.bazel.metainfo.xml
@@ -3,7 +3,9 @@
   <id>org.freedesktop.Sdk.Extension.bazel</id>
   <name>Bazel</name>
   <summary>Bazel build system</summary>
-  <description>This SDK extension enables you to build apps using the bazel build system.</description>
+  <description>
+	  <p>This SDK extension enables you to build apps using the bazel build system.</p>
+  </description>
   <url type="homepage">https://bazel.build/</url>
   <project_license>Apache-2.0</project_license>
   <metadata_license>CC0-1.0</metadata_license>


### PR DESCRIPTION
flatpak-builder-lint was showing an error about the description format. Wrapping the text in <p> tags fixes the issue and follows the required style.